### PR TITLE
Fix issue with multiple fields named "sprint"

### DIFF
--- a/SprintReport/sprint_report.py
+++ b/SprintReport/sprint_report.py
@@ -34,7 +34,7 @@ def find_issue_in_jira_sprint(jira_api, project, sprint):
     while True:
         start_index = issue_index * issue_batch
         request = "project = {} " \
-            "AND sprint = \"{}\" " \
+            "AND cf[10020] = \"{}\" " \
             "AND status = Done ORDER BY type".format(project, sprint)
         issues = jira_api.search_issues(request, startAt=start_index)
 


### PR DESCRIPTION
It appears that another field named "sprint" has been introduced recently, which leads to an exception when running the script. Changing the field name to a unique identifier used by Jira fixes the issue.